### PR TITLE
!map and !delete improvements. Automatically remove maps when tested on the server.

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
 </configuration>

--- a/SteamBotLite.csproj
+++ b/SteamBotLite.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SteamBotLite</RootNamespace>
     <AssemblyName>SteamBotLite</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/UserHandlers/VBot.cs
+++ b/UserHandlers/VBot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using SteamKit2;
 using System.Timers;
 using System.Collections.Generic;
@@ -48,13 +48,13 @@ namespace SteamBotLite
             mapModule = new MapModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["MapModule"].ToString()));
             mapModule.mapList.CollectionChanged += OnMaplistchange;
 
-         //   serverModule = new ServerModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["ServerModule"].ToString()));
+            serverModule = new ServerModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["ServerModule"].ToString()));
             usersModule = new UsersModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["usersModule"].ToString()));
             replyModule = new RepliesModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["ReplyModule"].ToString()));
 
             ModuleList = new List<BaseModule> { motdModule,mapModule,/*serverModule,*/usersModule,replyModule};
-            
-      //      serverModule.mapBeingTested += mapModule.HandleEvent;
+
+            serverModule.ServerUpdated += mapModule.HandleEvent;
 
             // loading module commands
             foreach (BaseModule module in ModuleList)

--- a/UserHandlers/VBot/Modules/Map.cs
+++ b/UserHandlers/VBot/Modules/Map.cs
@@ -29,12 +29,12 @@ namespace SteamBotLite
             adminCommands.Add(new Wipe(bot, this));
         }
 
-        public struct Map
+        public class Map
         {
-            public uint submitter;
-            public string filename;
-            public string downloadURL;
-            public string notes;
+            public uint Submitter { get; set; }
+            public string Filename { get; set; }
+            public string DownloadURL { get; set; }
+            public string Notes { get; set; }
         }
 
         public override string getPersistentData()
@@ -83,20 +83,20 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
                 Map map = new Map();
                 if (parameters.Length > 0)
                 {
-                    map.submitter = sender.AccountID;
-                    map.filename = parameters[0];
-                    map.notes = "No Notes";
+                    map.Submitter = sender.AccountID;
+                    map.Filename = parameters[0];
+                    map.Notes = "No Notes";
                     if (parameters.Length > 1 /* && !uploaded*/)
                     {
                         if (parameters.Length > 2)
                         {
-                            map.notes = param.Substring(parameters[0].Length + parameters[1].Length);
+                            map.Notes = param.Substring(parameters[0].Length + parameters[1].Length);
                         }
-                        map.downloadURL = parameters[1];
+                        map.DownloadURL = parameters[1];
                         MapModule.mapList.Add(map);
                         MapModule.savePersistentData();
 
-                        return string.Format("Map '{0}' added.", map.filename);
+                        return string.Format("Map '{0}' added.", map.Filename);
                     }
                 }
                 return "Invalid parameters for !add. Syntax: !add <mapname> <url> (notes)";
@@ -124,9 +124,9 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
                     if (i < MapModule.MaxMapNumber)
                     {
                         maplist += " , ";
-                        maplist += m.filename;
+                        maplist += m.Filename;
                     }
-                    extralist += m.filename + ": " + m.downloadURL + " Note: " + m.notes;
+                    extralist += m.Filename + ": " + m.DownloadURL + " Note: " + m.Notes;
                     i++;
                 }
                 if (string.IsNullOrEmpty(maplist))
@@ -149,22 +149,22 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
                 }
                 else
                 {
-                    Map editedMap = MapModule.mapList.Where(x => x.filename.Equals(parameters[0])).FirstOrDefault(); //Needs to be tested
+                    Map editedMap = MapModule.mapList.Where(x => x.Filename.Equals(parameters[0])).FirstOrDefault(); //Needs to be tested
                     // Map editedMap = MapModule.mapList.Find(map => map.filename.Equals(parameters[0])); //OLD Map CODE
-                    if (editedMap.submitter == sender.AccountID)
+                    if (editedMap.Submitter == sender.AccountID)
                     {
                         MapModule.mapList.Remove(editedMap);
 
-                        editedMap.filename = parameters[1];
+                        editedMap.Filename = parameters[1];
                         if (parameters.Length > 2)
-                            editedMap.downloadURL = parameters[2];
+                            editedMap.DownloadURL = parameters[2];
                         MapModule.mapList.Add(editedMap);
                         MapModule.savePersistentData();
-                        return string.Format("Map '{0}' has been edited.", editedMap.filename);
+                        return string.Format("Map '{0}' has been edited.", editedMap.Filename);
                     }
                     else
                     {
-                        return string.Format("You cannot edit map '{0}' as you did not submit it.", editedMap.filename);
+                        return string.Format("You cannot edit map '{0}' as you did not submit it.", editedMap.Filename);
                     }
                 }
             }
@@ -179,17 +179,24 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
 
                 if (parameters.Length > 0)
                 {
-                    Map deletedMap = MapModule.mapList.Where(x => x.filename.Equals(parameters[0])).FirstOrDefault(); //Needs to be tested 
-              //      Map deletedMap = MapModule.mapList.Find(map => map.filename.Equals(parameters[0]));
-                    if ((deletedMap.submitter == sender.AccountID) || (userhandler.usersModule.admincheck(sender.AccountID)))
+                    Map deletedMap = MapModule.mapList.FirstOrDefault(x => x.Filename == parameters[0]);
+
+                    if (deletedMap == null)
                     {
-                        MapModule.mapList.Remove(deletedMap);
-                        MapModule.savePersistentData();
-                        return string.Format("Map '{0}' DELETED.", deletedMap.filename);
+                        return string.Format("Map '{0}' was not found.");
                     }
                     else
                     {
-                        return string.Format("You do not have permission to edit map '{0}'.", deletedMap.downloadURL);
+                        if ((deletedMap.Submitter == sender.AccountID) || (userhandler.usersModule.admincheck(sender.AccountID)))
+                        {
+                            MapModule.mapList.Remove(deletedMap);
+                            MapModule.savePersistentData();
+                            return string.Format("Map '{0}' DELETED.", deletedMap.Filename);
+                        }
+                        else
+                        {
+                            return string.Format("You do not have permission to edit map '{0}'.", deletedMap.DownloadURL);
+                        }
                     }
                 }
                 return "Invalid parameters for !delete. Syntax: !delete <mapname>";

--- a/UserHandlers/VBot/Modules/Map.cs
+++ b/UserHandlers/VBot/Modules/Map.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -52,11 +52,14 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
             catch { }
         }
 
-        public void HandleEvent(object sender, EventArgs args)
+        public void HandleEvent(object sender, ServerModule.ServerInfo args)
         {
-            ServerModule.ServerInfo imp = (ServerModule.ServerInfo) args;
-          
-            //mapList.RemoveAll(x => x.filename == imp.currentMap); //OLD MAP SYSTEM
+            var map = mapList.FirstOrDefault(x => x.Filename == args.currentMap);
+            if (map != null)
+            {
+                mapList.Remove(map);
+                Console.WriteLine("Map {0} is being tested on the {1} server and has been removed.", map.Filename, args.tag);
+            }
         }
 
         // The abstract command for motd

--- a/UserHandlers/VBot/Modules/Map.cs
+++ b/UserHandlers/VBot/Modules/Map.cs
@@ -200,7 +200,7 @@ mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.Fil
 
                     if (deletedMap == null)
                     {
-                        return string.Format("Map '{0}' was not found.");
+                        return string.Format("Map '{0}' was not found.", parameters[0]);
                     }
                     else
                     {

--- a/UserHandlers/VBot/Modules/Server.cs
+++ b/UserHandlers/VBot/Modules/Server.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,11 +12,12 @@ namespace SteamBotLite
 {
     class ServerModule : BaseModule
     {
+        public event EventHandler<ServerInfo> ServerUpdated;
+
         public List<ServerInfo> serverList;
         private BaseTask serverUpdate;
         bool chatIsNotified = true;
 
-        //   public event EventHandler mapBeingTested; //Disabled as it is likely causing major Crashes. 
         public ServerModule(VBot bot, Dictionary<string, object> config) : base(bot, config)
         {
             serverList = new List<ServerInfo>();
@@ -54,16 +55,15 @@ namespace SteamBotLite
             {
                 this.serverIP = serverIP;
                 this.tag = tag;
-                currentMap = "";
-                playerCount = 0;
-                capacity = 0;
             }
+
             public void update(ServerInfo updated)
             {
                 this.playerCount = updated.playerCount;
                 this.capacity = updated.capacity;
                 this.currentMap = updated.currentMap;
             }
+
             public override string ToString()
             {
                 return this.tag + " server is now on " + this.currentMap +
@@ -80,7 +80,7 @@ namespace SteamBotLite
 
                 if (serverstate != null)
                 {
-                    bool mapUpdated = !serverstate.currentMap.Equals(server.currentMap) && !server.currentMap.Equals(string.Empty);
+                    bool mapUpdated = serverstate.currentMap != server.currentMap && server.currentMap != string.Empty;
                     server.update(serverstate);
 
                     if (mapUpdated)
@@ -99,6 +99,8 @@ namespace SteamBotLite
                         userhandler.steamConnectionHandler.SteamFriends.SendChatRoomMessage(userhandler.GroupChatSID, EChatEntryType.ChatMsg, server.ToString());
                         chatIsNotified = true;                        
                     }
+
+                    ServerUpdated?.Invoke(this, server);
                 }
             }
         }

--- a/UserHandlers/VBot/Modules/Server.cs
+++ b/UserHandlers/VBot/Modules/Server.cs
@@ -100,7 +100,8 @@ namespace SteamBotLite
                         chatIsNotified = true;                        
                     }
 
-                    ServerUpdated?.Invoke(this, server);
+                    if (ServerUpdated != null)
+                        ServerUpdated(this, server);
                 }
             }
         }


### PR DESCRIPTION
1) Map struct is now a class. This is more appropriate than a struct, as a Map is technically an object, and not a value.

The other advantage is that it can be null, so if you use FirstOrDefault (like you did), it will return a null value that you can check against. A struct would just have its default values which isn't particularly useful.

2) Map fields are now properties. It is standard to make exposed values properties instead of fields.

3) New Chat format for !map command:

**Under Limit**
cp_map , cp_map_2 , cp_map_3

**Over Limit (Limit of 2)**
cp_map , cp_map_2 (and 1 more...)

4) New PM format for !map command:

**No Notes**
cp_map // www.link.com
cp_map_2 // www.link.com
cp_map_3 // www.link.com

**With Notes**
cp_map // www.link.com
Notes: Uploaded
cp_map_2 // www.link.com
cp_map_3 // www.link.com
Notes: Added more doggos

5) !delete commands now checks if the map exists and offers feedback:

** Map Not Found **
"Map 'cp_map' was not found."