### PR TITLE
Various Major bug Fixes 

### DIFF
--- a/UserHandlers/VBot.cs
+++ b/UserHandlers/VBot.cs
@@ -142,6 +142,7 @@ namespace SteamBotLite
             }
             if (CrashCheck >= 4)
             {
+                CrashCheck = 0; 
                 Reboot();
             }
         }

--- a/UserHandlers/VBot.cs
+++ b/UserHandlers/VBot.cs
@@ -18,6 +18,7 @@ namespace SteamBotLite
         int CrashCheck = 0;
         public string Username = "V2Bot";
         Timer Tick;
+        bool Autojoin = true; 
 
         // Class members
         MotdModule motdModule;
@@ -37,12 +38,16 @@ namespace SteamBotLite
         {
             Console.WriteLine("Vbot Initialised");
             Console.WriteLine("Loading modules and stuff");
-
-            // loading config
+            
+            // Loading Config
             Dictionary<string, object> jsconfig = JsonConvert.DeserializeObject<Dictionary<string, object>>(System.IO.File.ReadAllText(@"config.json"));
             GroupChatID = ulong.Parse((string)jsconfig["GroupchatID"]);
             GroupChatSID = new SteamID(GroupChatID);
-
+            try {
+                Autojoin = Convert.ToBoolean(jsconfig["AutoJoin"]);
+            } catch { };
+             
+           
             // loading modules
             motdModule = new MotdModule(this, JsonConvert.DeserializeObject<Dictionary<string, object>>(jsconfig["MotdModule"].ToString()));
 
@@ -70,7 +75,8 @@ namespace SteamBotLite
         public override void OnLoginCompleted()
         {
             steamConnectionHandler.SteamFriends.SetPersonaName("V2Bot");
-            steamConnectionHandler.SteamFriends.JoinChat(GroupChatSID);
+            if (Autojoin)
+                steamConnectionHandler.SteamFriends.JoinChat(GroupChatSID);
             InitTimer();
             Console.WriteLine("{0} User: {1} Is now online", steamConnectionHandler.ID, steamConnectionHandler.LoginData.Username); //Lets tell the User we're now online
         }

--- a/UserHandlers/VBot/BaseModule.cs
+++ b/UserHandlers/VBot/BaseModule.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
+using System.IO;
 
 namespace SteamBotLite
 {
@@ -12,8 +12,10 @@ namespace SteamBotLite
         public List<BaseCommand> commands {get; private set;}
         public List<BaseCommand> adminCommands {get; private set;}
         public List<BaseTask> tasks { get; private set;}
-        public string SavedData()
+        public string ModuleSavedDataFilePath()
         {
+            
+            return Path.Combine(userhandler.GetType().Name, this.GetType().Name + ".json");
             return this.GetType().Name + ".json";
         }
         
@@ -33,7 +35,16 @@ namespace SteamBotLite
         public void savePersistentData()
         {
             string jsonData = getPersistentData();
-            System.IO.File.WriteAllText(this.GetType().Name + ".json", jsonData);
+            if (Directory.Exists(ModuleSavedDataFilePath()))
+            {
+                System.IO.File.WriteAllText(ModuleSavedDataFilePath(), jsonData);
+            }
+            else
+            {
+                Directory.CreateDirectory(userhandler.GetType().Name);
+                System.IO.File.WriteAllText(ModuleSavedDataFilePath(), jsonData);
+            };
+            
         }
 
         abstract public string getPersistentData();

--- a/UserHandlers/VBot/Modules/Map.cs
+++ b/UserHandlers/VBot/Modules/Map.cs
@@ -46,10 +46,14 @@ namespace SteamBotLite
         {
             try
             {
-                ObservableCollection<Map>
-mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.File.ReadAllText(this.GetType().Name + ".json"));
+                Console.WriteLine("Loading Map List");
+                mapList = JsonConvert.DeserializeObject<ObservableCollection<Map>>(System.IO.File.ReadAllText(this.GetType().Name + ".json"));
+                Console.WriteLine("Loaded Map List");
             }
-            catch { }
+            catch
+            {
+                Console.WriteLine("Error Loading Map List");
+            }
         }
 
         public void HandleEvent(object sender, ServerModule.ServerInfo args)

--- a/UserHandlers/VBot/Modules/Replies.cs
+++ b/UserHandlers/VBot/Modules/Replies.cs
@@ -108,9 +108,9 @@ namespace SteamBotLite
 
                 Dictionary<string, string> values = replymodule.GetDataDictionary();
 
-                if (values.ContainsKey(command[0]) && (command.Length > 1))
+                if (values.ContainsKey(command[1]) && (command.Length > 1))
                 {
-                    values.Remove(command[0]);
+                    values.Remove(command[1]);
                     System.IO.File.WriteAllText(replymodule.SaveDataFile, JsonConvert.SerializeObject(values));
                     userhandler.chatCommands.Add(new Reply(userhandler, replymodule, new KeyValuePair<string, string>(command[0], command[1])));
                     return "Reply Removed";

--- a/UserHandlers/VBot/Modules/Replies.cs
+++ b/UserHandlers/VBot/Modules/Replies.cs
@@ -26,7 +26,7 @@ namespace SteamBotLite
             }
             adminCommands.Add(new ReplyAdd(bot, this));
             adminCommands.Add(new ReplyRemove(bot, this));
-            adminCommands.Add(new Reply(bot, this, new KeyValuePair<string, string>("!PathTest", SavedData())));
+            adminCommands.Add(new Reply(bot, this, new KeyValuePair<string, string>("!PathTest", ModuleSavedDataFilePath())));
         }
 
         public override string getPersistentData()

--- a/UserHandlers/VBot/Modules/Server.cs
+++ b/UserHandlers/VBot/Modules/Server.cs
@@ -80,29 +80,15 @@ namespace SteamBotLite
 
                 if (serverstate != null)
                 {
-                    //Is the "ISChatNotified" nessecary? Can't we just check the vars then run? 
-                    bool mapUpdated = (serverstate.currentMap != server.currentMap) && (server.currentMap != string.Empty);
-                    server.update(serverstate);
-
-                    if (mapUpdated)
-                        chatIsNotified = false;
-                    
-                    if ((!chatIsNotified) && (server.playerCount > 3))
+                    if ((serverstate.currentMap != server.currentMap) && (server.currentMap != string.Empty) /*&& (server.playerCount > 3)*/)
                     {
-                        /* //TODO Re-Enabled
-                        EventHandler handler = mapBeingTested; 
-
-                        if (handler != null)
-                        {
-                            handler(this, server);
-                        }
-                        */
-                    //    userhandler.steamConnectionHandler.SteamFriends.SendChatRoomMessage(userhandler.GroupChatSID, EChatEntryType.ChatMsg, server.ToString()); //Disabled as it will keep spamming chat 
-                        chatIsNotified = true;                        
-                    }
-
-                    if (ServerUpdated != null)
+                        Console.WriteLine("Going to Update Server Data");
+                        server.update(serverstate);
+                        Console.WriteLine("Going to delete Map");
                         ServerUpdated(this, server);
+                        Console.WriteLine("Posting In Chat");
+                        userhandler.steamConnectionHandler.SteamFriends.SendChatRoomMessage(userhandler.GroupChatSID, EChatEntryType.ChatMsg, server.ToString()); 
+                    }
                 }
             }
         }

--- a/UserHandlers/VBot/Modules/Server.cs
+++ b/UserHandlers/VBot/Modules/Server.cs
@@ -80,13 +80,14 @@ namespace SteamBotLite
 
                 if (serverstate != null)
                 {
-                    bool mapUpdated = serverstate.currentMap != server.currentMap && server.currentMap != string.Empty;
+                    //Is the "ISChatNotified" nessecary? Can't we just check the vars then run? 
+                    bool mapUpdated = (serverstate.currentMap != server.currentMap) && (server.currentMap != string.Empty);
                     server.update(serverstate);
 
                     if (mapUpdated)
                         chatIsNotified = false;
                     
-                    if (!chatIsNotified && server.playerCount > 3)
+                    if ((!chatIsNotified) && (server.playerCount > 3))
                     {
                         /* //TODO Re-Enabled
                         EventHandler handler = mapBeingTested; 


### PR DESCRIPTION
Added an autojoin parameter to the config
Modulesavepath() is a string for modules that needs to be used across all of them for storage, currently only in the map module
CrashCheck now resets on reboot
Submitters are stored as a steamid as this allows them to be messaged on servers playing maps (need to make in a smaller format however) 
Now Deletes played maps
Can Delete Replies 